### PR TITLE
Fix missing max(0,...) clamp on fasta.fetch() in add_normal_counts

### DIFF
--- a/bin/find_edited_reads.py
+++ b/bin/find_edited_reads.py
@@ -837,7 +837,7 @@ def add_normal_counts(df, reads, fasta, flank=300, debug=False):
         alt = row['alt']
         
         start_idx = pos - 1
-        ref_seq = fasta.fetch(chrom, start_idx - flank, start_idx + len(ref) + flank)
+        ref_seq = fasta.fetch(chrom, max(0, start_idx - flank), start_idx + len(ref) + flank)
         
         alt_seq = ref_seq
         if alt != '.':


### PR DESCRIPTION
## Summary

- `add_normal_counts()` called `fasta.fetch(chrom, start_idx - flank, ...)` at line 840 without clamping the start coordinate, causing a `ValueError: start out of range` when a variant sits within `flank` bases of the chromosome start (e.g. IKZF2-KO-DNA hit this with start = -65).
- PR #10 (commit `6e5b425`) fixed the same pattern in `generate_contig()` but missed this call.
- Fix: `max(0, start_idx - flank)`, consistent with all other fetch calls in the file.

## Reproduction

IKZF2-KO-DNA WGS sample hit a target site near chromosome start, crashing with:
```
ref_seq = fasta.fetch(chrom, start_idx - flank, start_idx + len(ref) + flank)
ValueError: start out of range (-65)
```