### PR TITLE
offtarget: PR-AUC and recall-weighted F-beta (F2/F5) as pipeline outputs

### DIFF
--- a/bin/offtarget_metrics.py
+++ b/bin/offtarget_metrics.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python3
+"""
+offtarget_metrics.py — the metrics a recall-first diagnostic is actually judged on.
+
+Reports PR-AUC and recall-weighted F-beta (F2, F5) for the WGS shape score, plus the
+precision/recall/F1 at the operating point the pipeline actually reports (verdict =
+LIKELY EDIT). ROC-AUC is carried for continuity but is deliberately NOT the headline:
+at low positive prevalence it is dominated by the true-negative mass and flatters the
+ranker. PR-AUC has no such property, which is why it leads here.
+
+    F_beta = (1 + beta^2) * P * R / (beta^2 * P + R)
+
+beta weights recall beta^2x more than precision (beta=2 -> 4x, beta=5 -> 25x). F_beta is
+MONOTONE in beta: it rises with beta when R > P and falls when P > R, and always lies
+between min(P, R) and max(P, R). So F1 is always an endpoint of {F1, F2, F5}, never the
+middle value — if you see F1 in the middle, the beta wiring is inverted.
+
+WHY THESE METRICS ARE NOT COMPUTED AGAINST THE MANUAL REVIEW
+------------------------------------------------------------
+This is the trap this script exists to avoid. The human-reviewed gold standard
+(`cart_ecs_merged.csv.gz`) has 55 rows with manual_review == '1', 1 with '1?', and
+80,440 NaN. **NaN means NOT REVIEWED, not reviewed-and-rejected.** There are no
+confirmed negatives in it at all.
+
+Precision therefore CANNOT be computed against that table. Treating NaN as negative
+would count every genuine discovery the reviewers never got to as a false positive and
+manufacture a confidently wrong number. That is why `validate_recall.py` reports recall
+only, and why it stays the gold standard for recall. Do not "fix" it by filling NaN.
+
+So there are two denominators, and this script keeps them strictly apart:
+
+  1. RANKING + PRECISION  ->  training.tsv, which has a genuine two-class ECS label.
+                              That is what this script computes. Precision here is
+                              precision against the ECS label, NEVER against human review.
+  2. RECALL vs HUMAN REVIEW -> `validate_recall.py`, reported as recall alone, unchanged.
+
+Both denominators are stamped into the JSON and the text report so a reader months later
+cannot mistake one for the other.
+
+THE POSITIVE SET (same credibility gates as the recall curve)
+-------------------------------------------------------------
+A raw `label == 1` counts ANY nonzero ECS indel fraction as an edit, which at ECS depth
+is overwhelmingly noise. Positives are therefore gated exactly as `recall_vs_vaf.py`
+gates its denominator:
+
+    label == 1  AND  ecs_if >= --min-ecs-vaf  AND  ecs_indel_reads >= --min-ecs-reads
+
+`label == 1` rows failing those gates are AMBIGUOUS, not negative: ECS saw something,
+below the credibility floor. They are EXCLUDED and counted, for the same reason the
+unreviewed manual-review rows are excluded — asserting they are negatives is an
+assumption the data does not support. `--ambiguous-as-negative` reports the alternative,
+and the JSON always carries it as a labelled sensitivity block so the choice is visible.
+
+THE NEGATIVE SET
+----------------
+`label == 0` is two different things:
+  * ecs_is_edit == 0  — a genuine ECS-negative at a scored hotspot (a true negative);
+  * ecs_is_edit == 1  — an ECS edit DEMOTED because the indel is in the matched normal
+                        (germline/artifact).
+The germline-demoted rows carry a real indel, so the shape model correctly scores their
+pileup shape high — germline rejection is a separate downstream gate (their verdict is
+`GERMLINE/ARTIFACT (in normal)`, and none are called LIKELY EDIT). Ranking the shape
+score against them charges it with a job it does not do and is not asked to do, so the
+default negative set is `ecs_negative`. `--negatives all_label0` gives the stricter view
+and is reported as a sensitivity block either way.
+"""
+import argparse
+import json
+import sys
+
+import numpy as np
+import pandas as pd
+
+# VAF floors for the stratified view. A single PR-AUC over all credible positives is
+# dominated by sub-1% VAF sites that WGS at ~30x genuinely cannot see, so it understates
+# the ranker exactly where the ranker is usable. Stratifying by ECS VAF separates
+# "the model cannot rank" from "the data has no signal at this depth".
+VAF_FLOORS = [0.005, 0.01, 0.02, 0.05, 0.10]
+
+DETECT_PATTERN = "LIKELY EDIT"
+UNEVALUABLE_PATTERN = "INSUFFICIENT COVERAGE|NO CRAM"
+
+MANUAL_REVIEW_NOTE = (
+    "Precision is NOT computable against the human manual review: that table has 55 "
+    "confirmed positives ('1'), 1 '1?', and 80,440 NaN, where NaN means UNREVIEWED, not "
+    "rejected. It contains no confirmed negatives, so any precision computed from it "
+    "would score every discovery the reviewers never reached as a false positive. All "
+    "precision/PR-AUC/F-beta figures in this file use the ECS label in training.tsv as "
+    "their denominator. Recall against human review is reported separately, and as "
+    "recall only, by bin/validate_recall.py."
+)
+
+
+def fbeta(precision, recall, beta):
+    """F_beta = (1 + b^2) * P * R / (b^2 * P + R); 0 when the denominator vanishes."""
+    denom = (beta * beta * precision) + recall
+    if denom <= 0:
+        return 0.0
+    return float((1.0 + beta * beta) * precision * recall / denom)
+
+
+def build_masks(df, args):
+    """Split the training table into credible positives / negatives / ambiguous."""
+    label = pd.to_numeric(df.get("label"), errors="coerce")
+    vaf = pd.to_numeric(df.get("ecs_if"), errors="coerce").fillna(0.0)
+
+    gate = vaf >= args.min_ecs_vaf
+    warn = None
+    if "ecs_indel_reads" in df.columns:
+        reads = pd.to_numeric(df["ecs_indel_reads"], errors="coerce").fillna(0)
+        gate &= reads >= args.min_ecs_reads
+    elif args.min_ecs_reads > 0:
+        # Same guard as recall_vs_vaf.py: a table built before read support was carried
+        # through silently disables half the credibility gate. Warn, never pass quietly.
+        warn = (f"training table has no ecs_indel_reads column (produced before read "
+                f"support was carried through) — the --min-ecs-reads {args.min_ecs_reads} "
+                f"filter is INACTIVE and the positive set may still contain ECS noise")
+        print(f"WARN: {warn}", file=sys.stderr)
+
+    pos = (label == 1) & gate
+    ambiguous = (label == 1) & ~gate
+
+    if args.negatives == "ecs_negative" and "ecs_is_edit" in df.columns:
+        ecs_edit = pd.to_numeric(df["ecs_is_edit"], errors="coerce").fillna(0)
+        neg = (label == 0) & (ecs_edit == 0)
+        neg_germline = (label == 0) & (ecs_edit != 0)
+    else:
+        neg = (label == 0)
+        neg_germline = pd.Series(False, index=df.index)
+
+    if args.ambiguous_as_negative:
+        neg = neg | ambiguous
+        ambiguous = pd.Series(False, index=df.index)
+
+    return pos, neg, ambiguous, neg_germline, warn
+
+
+def score_and_calls(df, hi):
+    """Continuous score + the reported operating point + the unevaluable mask.
+
+    The operating point must be what the pipeline actually REPORTS. The scorer can call
+    a LIKELY EDIT via the high-evidence rescue at a sub-`hi` model score, so scoring the
+    raw threshold alone would under-count exactly those recovered edits. Prefer the
+    verdict; fall back to `score >= hi` only for verdict-less tables. Same precedence as
+    recall_vs_vaf.py, so the two files agree on what "detected" means.
+    """
+    score = pd.to_numeric(df.get("score"), errors="coerce")
+    if "verdict" in df.columns:
+        verdict = df["verdict"].astype(str)
+        called = verdict.str.contains(DETECT_PATTERN, na=False)
+        uneval = verdict.str.contains(UNEVALUABLE_PATTERN, na=False)
+        criterion = f"verdict contains '{DETECT_PATTERN}'"
+    else:
+        called = (score >= hi).fillna(False)
+        uneval = score.isna()
+        criterion = f"score >= {hi} (table has no verdict column)"
+    return score, called, uneval, criterion
+
+
+def ranking_metrics(y, s):
+    """PR-AUC / ROC-AUC on a finite-score, two-class subset. None when undefined."""
+    from sklearn.metrics import average_precision_score, roc_auc_score
+    out = {"pr_auc": None, "roc_auc": None}
+    if len(y) == 0 or len(np.unique(y)) < 2:
+        return out
+    out["pr_auc"] = float(average_precision_score(y, s))
+    out["roc_auc"] = float(roc_auc_score(y, s))
+    return out
+
+
+def evaluate(df, pos, neg, score, called, uneval, betas, criterion=None):
+    """Full metric block for one positive/negative definition."""
+    m = pos | neg
+    y_all = pos[m].astype(int).to_numpy()
+    s_all = score[m].to_numpy()
+    called_all = called[m].to_numpy()
+    uneval_all = uneval[m].to_numpy()
+
+    # Rows with no score (INSUFFICIENT COVERAGE / NO CRAM) are excluded from the ranking
+    # metrics: average_precision_score needs a continuous score, and filling them with 0
+    # would fabricate confident negatives. They are counted, not hidden.
+    finite = np.isfinite(s_all)
+    y, s, pred = y_all[finite], s_all[finite], called_all[finite].astype(int)
+
+    n_pos, n_neg = int((y == 1).sum()), int((y == 0).sum())
+    block = {
+        "n_pos": n_pos,
+        "n_neg": n_neg,
+        "n_total": n_pos + n_neg,
+        "prevalence": float(y.mean()) if len(y) else None,
+        "n_excluded_no_score": int((~finite).sum()),
+        "n_excluded_no_score_pos": int((y_all[~finite] == 1).sum()),
+        "n_excluded_no_score_neg": int((y_all[~finite] == 0).sum()),
+        "n_unevaluable": int(uneval_all.sum()),
+    }
+    block.update(ranking_metrics(y, s))
+
+    tp = int(((pred == 1) & (y == 1)).sum())
+    fp = int(((pred == 1) & (y == 0)).sum())
+    fn = int(((pred == 0) & (y == 1)).sum())
+    tn = int(((pred == 0) & (y == 0)).sum())
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+
+    op = {
+        "criterion": criterion or f"verdict contains '{DETECT_PATTERN}'",
+        "tp": tp, "fp": fp, "fn": fn, "tn": tn,
+        "precision": float(precision),
+        "recall": float(recall),
+        "f1": fbeta(precision, recall, 1.0),
+        # Pessimistic view: charge the no-score positives against recall as well, the
+        # same split recall_vs_vaf.csv makes with recall vs recall_incl_unevaluable.
+        "recall_incl_unevaluable": (
+            float(tp / int((y_all == 1).sum())) if int((y_all == 1).sum()) else None),
+    }
+    for b in betas:
+        op[f"f{_beta_key(b)}"] = fbeta(precision, recall, b)
+    block["operating_point"] = op
+
+    # PR-AUC below prevalence is the "useless ranker or a bug" tripwire from the design
+    # notes. Here it is usually neither: it is the WGS depth floor showing up, because
+    # the credible-positive set is dominated by sub-1% VAF sites. Say so rather than
+    # emit a bare number that reads as a broken model.
+    if block["pr_auc"] is not None and block["prevalence"] is not None:
+        block["pr_auc_lift_over_prevalence"] = (
+            float(block["pr_auc"] / block["prevalence"]) if block["prevalence"] else None)
+    return block
+
+
+def _beta_key(b):
+    """2.0 -> '2', 2.5 -> '2.5' — keeps the common case reading as f2/f5."""
+    return str(int(b)) if float(b).is_integer() else str(b)
+
+
+def vaf_stratified(df, pos, neg, score, called, uneval, betas, args):
+    """PR-AUC vs prevalence as the ECS VAF floor on the POSITIVE set rises."""
+    vaf = pd.to_numeric(df.get("ecs_if"), errors="coerce").fillna(0.0)
+    rows = []
+    for floor in VAF_FLOORS:
+        if floor < args.min_ecs_vaf:
+            continue
+        p = pos & (vaf >= floor)
+        if int(p.sum()) == 0:
+            continue
+        b = evaluate(df, p, neg, score, called, uneval, betas)
+        rows.append({
+            "ecs_vaf_floor": floor,
+            "n_pos": b["n_pos"], "n_neg": b["n_neg"],
+            "prevalence": b["prevalence"], "pr_auc": b["pr_auc"],
+            "pr_auc_lift_over_prevalence": b.get("pr_auc_lift_over_prevalence"),
+            "roc_auc": b["roc_auc"],
+            "recall": b["operating_point"]["recall"],
+            "precision": b["operating_point"]["precision"],
+        })
+    return rows
+
+
+def fmt(v, spec=".4f"):
+    return "n/a" if v is None or (isinstance(v, float) and not np.isfinite(v)) \
+        else format(v, spec)
+
+
+def render_text(out, betas):
+    """One screen. Every number carries the denominator it was computed against."""
+    m = out["metrics"]
+    op = m["operating_point"] if m else None
+    L = []
+    A = L.append
+    A("=" * 78)
+    A("OFF-TARGET CLINICAL METRICS — PR-AUC and recall-weighted F-beta")
+    A("=" * 78)
+    A(f"training table : {out['inputs']['training']}")
+    A(f"rows           : {out['inputs']['n_rows']}")
+    A("")
+    A("-- DENOMINATOR 1 of 2: the ECS label (this is what every number below uses) --")
+    A(f"  positives : label==1 AND ecs_if >= {out['inputs']['min_ecs_vaf']} "
+      f"AND ecs_indel_reads >= {out['inputs']['min_ecs_reads']}")
+    A(f"  negatives : {out['inputs']['negatives']}"
+      f"{'  (label==0 AND ecs_is_edit==0)' if out['inputs']['negatives'] == 'ecs_negative' else '  (all label==0)'}")
+    counts = out.get("counts") or {}
+    A(f"  ambiguous : {counts.get('n_ambiguous', 0)} label==1 rows below the credibility "
+      f"floor — EXCLUDED, not counted as negatives")
+    if counts.get("n_germline_demoted_excluded"):
+        A(f"  excluded  : {counts['n_germline_demoted_excluded']} germline-demoted "
+          f"label==0 rows (indel in the matched normal; rejected by a separate gate)")
+    A("")
+    A("-- DENOMINATOR 2 of 2: the human manual review --")
+    for line in _wrap(MANUAL_REVIEW_NOTE, 74):
+        A(f"  {line}")
+    A("")
+    if not m:
+        A(f"NOTE: {out['note']}")
+        A("=" * 78)
+        return "\n".join(L) + "\n"
+
+    A("-- RANKING (score as a continuous ranker; ECS-label denominator) --")
+    A(f"  n_pos / n_neg      : {m['n_pos']} / {m['n_neg']}   prevalence {fmt(m['prevalence'])}")
+    A(f"  PR-AUC             : {fmt(m['pr_auc'])}"
+      + (f"   ({fmt(m.get('pr_auc_lift_over_prevalence'), '.2f')}x prevalence)"
+         if m.get("pr_auc_lift_over_prevalence") is not None else ""))
+    A(f"  ROC-AUC            : {fmt(m['roc_auc'])}   (kept for continuity; not the headline "
+      f"at low prevalence)")
+    A(f"  excluded, no score : {m['n_excluded_no_score']} "
+      f"({m['n_excluded_no_score_pos']} pos / {m['n_excluded_no_score_neg']} neg) — "
+      f"INSUFFICIENT COVERAGE / NO CRAM, never filled with 0")
+    A("")
+    A(f"-- OPERATING POINT ({op['criterion']}; ECS-label denominator) --")
+    A(f"  TP {op['tp']}   FP {op['fp']}   FN {op['fn']}   TN {op['tn']}")
+    A(f"  precision (vs ECS label, NOT vs human review) : {fmt(op['precision'])}")
+    A(f"  recall                                        : {fmt(op['recall'])}")
+    A(f"  recall incl. unevaluable                      : {fmt(op['recall_incl_unevaluable'])}")
+    A(f"  {'F1':<44s}: {fmt(op['f1'])}")
+    for b in betas:
+        k = f"f{_beta_key(b)}"
+        A(f"  {f'F{_beta_key(b)} (recall weighted {b * b:g}x)':<44s}: {fmt(op[k])}")
+    A("")
+    if out["by_vaf_floor"]:
+        A("-- BY ECS VAF FLOOR ON THE POSITIVE SET --")
+        A("   (a single PR-AUC over all credible positives is dominated by sub-1% VAF")
+        A("    sites that WGS at ~30x cannot see; this separates ranker from depth floor)")
+        A(f"   {'vaf>=':>7} {'n_pos':>6} {'n_neg':>6} {'prev':>7} {'PR-AUC':>7} {'lift':>6} {'ROC':>6}")
+        for r in out["by_vaf_floor"]:
+            A(f"   {r['ecs_vaf_floor']:>7g} {r['n_pos']:>6} {r['n_neg']:>6} "
+              f"{fmt(r['prevalence'], '.3f'):>7} {fmt(r['pr_auc'], '.3f'):>7} "
+              f"{fmt(r.get('pr_auc_lift_over_prevalence'), '.2f'):>6} "
+              f"{fmt(r['roc_auc'], '.3f'):>6}")
+        A("")
+    if out["sensitivity"]:
+        A("-- SENSITIVITY: the same score under other defensible denominators --")
+        for s in out["sensitivity"]:
+            A(f"   {s['definition']:<34} n_pos {s['n_pos']:>5}  n_neg {s['n_neg']:>5}  "
+              f"prev {fmt(s['prevalence'], '.3f')}  PR-AUC {fmt(s['pr_auc'], '.3f')}")
+        A("")
+    if out["notes"]:
+        A("-- NOTES --")
+        for n in out["notes"]:
+            for line in _wrap(n, 74):
+                A(f"  {line}")
+        A("")
+    A("=" * 78)
+    return "\n".join(L) + "\n"
+
+
+def _wrap(text, width):
+    words, line, lines = text.split(), "", []
+    for w in words:
+        if line and len(line) + 1 + len(w) > width:
+            lines.append(line)
+            line = w
+        else:
+            line = f"{line} {w}".strip()
+    if line:
+        lines.append(line)
+    return lines
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--training", required=True,
+                    help="training.tsv from join_training_table.py (needs label + score)")
+    ap.add_argument("--hi", type=float, default=0.60,
+                    help="score threshold; used only when the table has no verdict column")
+    ap.add_argument("--min-ecs-vaf", type=float, default=0.005,
+                    help="positive set: ECS VAF floor below which a call is assay noise")
+    ap.add_argument("--min-ecs-reads", type=int, default=5,
+                    help="positive set: ECS indel reads required to believe a site")
+    ap.add_argument("--beta", type=float, action="append", default=None, metavar="B",
+                    help="F-beta weight; repeatable (default: 2 and 5)")
+    ap.add_argument("--betas", help="comma-separated F-beta weights, e.g. '2,5'")
+    ap.add_argument("--negatives", choices=["ecs_negative", "all_label0"],
+                    default="ecs_negative",
+                    help="ecs_negative (default) = label==0 AND ecs_is_edit==0; "
+                         "all_label0 also includes germline-demoted ECS edits")
+    ap.add_argument("--ambiguous-as-negative", action="store_true",
+                    help="treat sub-credibility label==1 rows as negatives (NOT the "
+                         "default: ECS saw something there, so calling them negative is "
+                         "an assumption the data does not support)")
+    ap.add_argument("--out-json", default="offtarget_metrics.json")
+    ap.add_argument("--out-txt", default="offtarget_metrics.txt")
+    ap.add_argument("--out-curve", default=None, help="optional PR-curve PNG")
+    args = ap.parse_args()
+
+    betas = []
+    if args.betas:
+        betas += [float(b) for b in args.betas.replace(" ", "").split(",") if b]
+    if args.beta:
+        betas += list(args.beta)
+    betas = sorted(set(betas)) or [2.0, 5.0]
+
+    df = pd.read_csv(args.training, sep="\t")
+    notes = []
+
+    out = {
+        "inputs": {
+            "training": args.training,
+            "n_rows": int(len(df)),
+            "min_ecs_vaf": args.min_ecs_vaf,
+            "min_ecs_reads": args.min_ecs_reads,
+            "negatives": args.negatives,
+            "ambiguous_as_negative": bool(args.ambiguous_as_negative),
+            "betas": betas,
+            "hi": args.hi,
+        },
+        "denominators": {
+            "metrics_denominator": (
+                "ECS label in training.tsv: positives are label==1 gated to credible ECS "
+                "edits (ecs_if >= min_ecs_vaf AND ecs_indel_reads >= min_ecs_reads); "
+                f"negatives are '{args.negatives}'."),
+            "manual_review_denominator": MANUAL_REVIEW_NOTE,
+        },
+        "counts": {}, "metrics": None, "by_vaf_floor": [], "sensitivity": [],
+        "notes": notes, "note": None,
+    }
+
+    if "label" not in df.columns or "score" not in df.columns:
+        out["note"] = ("training table lacks a 'label' and/or 'score' column — no metrics "
+                       "computable")
+        _emit(out, betas, args)
+        return
+
+    pos, neg, ambiguous, neg_germline, warn = build_masks(df, args)
+    if warn:
+        notes.append(warn)
+    score, called, uneval, criterion = score_and_calls(df, args.hi)
+
+    out["counts"] = {
+        "n_positives_credible": int(pos.sum()),
+        "n_negatives": int(neg.sum()),
+        "n_ambiguous": int(ambiguous.sum()),
+        "n_germline_demoted_excluded": int(neg_germline.sum()),
+        "n_somatic_label1_total": int((pd.to_numeric(df["label"], errors="coerce") == 1).sum()),
+    }
+
+    # Degenerate cases are legitimate results, not errors: a run with no credible edits
+    # still has to publish a file. Emit nulls plus an explanatory note and exit 0.
+    if int(pos.sum()) == 0 or int(neg.sum()) == 0:
+        out["note"] = (
+            f"single-class evaluation set ({int(pos.sum())} credible positives, "
+            f"{int(neg.sum())} negatives) — PR-AUC and F-beta are undefined. This is a "
+            f"legitimate outcome for a run with no credible ECS edits, not a failure.")
+        _emit(out, betas, args)
+        return
+
+    out["metrics"] = evaluate(df, pos, neg, score, called, uneval, betas, criterion)
+
+    if out["metrics"]["n_pos"] == 0 or out["metrics"]["n_neg"] == 0:
+        out["note"] = ("every row of one class had a NaN score (INSUFFICIENT COVERAGE / "
+                       "NO CRAM) — ranking metrics undefined on the evaluable subset")
+
+    out["by_vaf_floor"] = vaf_stratified(df, pos, neg, score, called, uneval, betas, args)
+
+    # Sensitivity: show what the other defensible denominators would give, so the one
+    # judgement call in here is visible rather than buried in a default.
+    for definition, p2, n2 in _alternatives(df, pos, neg, ambiguous, neg_germline, args):
+        b = evaluate(df, p2, n2, score, called, uneval, betas)
+        out["sensitivity"].append({
+            "definition": definition, "n_pos": b["n_pos"], "n_neg": b["n_neg"],
+            "prevalence": b["prevalence"], "pr_auc": b["pr_auc"], "roc_auc": b["roc_auc"],
+        })
+
+    m = out["metrics"]
+    if m["pr_auc"] is not None and m["prevalence"] and m["pr_auc"] <= m["prevalence"]:
+        notes.append(
+            f"PR-AUC ({m['pr_auc']:.3f}) does not exceed prevalence "
+            f"({m['prevalence']:.3f}): over this positive set the score adds no ranking "
+            f"power. Check the by-VAF-floor table before concluding the model is broken "
+            f"— the credible-positive set is usually dominated by sub-1% VAF sites that "
+            f"WGS at ~30x cannot see, and the lift typically rises sharply with the VAF "
+            f"floor. A flat lift at every floor does indicate a real problem.")
+
+    _emit(out, betas, args)
+
+
+def _alternatives(df, pos, neg, ambiguous, neg_germline, args):
+    """(label, positives, negatives) triples for the sensitivity block."""
+    alts = []
+    if int(neg_germline.sum()):
+        alts.append(("negatives = all label==0", pos, neg | neg_germline))
+    if int(ambiguous.sum()) and not args.ambiguous_as_negative:
+        alts.append(("+ sub-credibility as negative", pos, neg | ambiguous))
+    label = pd.to_numeric(df.get("label"), errors="coerce")
+    ungated = (label == 1)
+    if int(ungated.sum()) != int(pos.sum()):
+        alts.append(("ungated label==1 (ECS noise incl.)", ungated, neg))
+    return alts
+
+
+def _emit(out, betas, args):
+    with open(args.out_json, "w") as fh:
+        json.dump(out, fh, indent=2)
+    text = render_text(out, betas)
+    with open(args.out_txt, "w") as fh:
+        fh.write(text)
+    print(text)
+    print(f"wrote {args.out_json} and {args.out_txt}")
+    if args.out_curve:
+        _plot(out, args)
+
+
+def _plot(out, args):
+    """PR curve with the operating point marked. A nicety — the JSON is the truth."""
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        from sklearn.metrics import precision_recall_curve
+
+        df = pd.read_csv(args.training, sep="\t")
+        pos, neg, _amb, _gd, _w = build_masks(df, args)
+        score, called, _u, _c = score_and_calls(df, args.hi)
+        m = pos | neg
+        y = pos[m].astype(int).to_numpy()
+        s = score[m].to_numpy()
+        ok = np.isfinite(s)
+        y, s, pred = y[ok], s[ok], called[m].to_numpy()[ok]
+        if len(np.unique(y)) < 2:
+            print("(PR curve not rendered: single-class evaluation set)")
+            return
+        p, r, _ = precision_recall_curve(y, s)
+        op = out["metrics"]["operating_point"]
+        fig, ax = plt.subplots(figsize=(7, 4.5))
+        ax.plot(r, p, "-", color="#2b6cb0", label=f"PR-AUC = {out['metrics']['pr_auc']:.3f}")
+        ax.axhline(out["metrics"]["prevalence"], ls="--", color="#a0aec0",
+                   label=f"prevalence = {out['metrics']['prevalence']:.3f}")
+        ax.plot([op["recall"]], [op["precision"]], "o", color="#c53030", ms=9,
+                label=f"LIKELY EDIT (P={op['precision']:.2f}, R={op['recall']:.2f})")
+        ax.set_xlabel("recall")
+        ax.set_ylabel("precision (vs ECS label — NOT vs human review)")
+        ax.set_xlim(-0.02, 1.02)
+        ax.set_ylim(-0.02, 1.02)
+        ax.set_title("WGS shape score — precision/recall vs the ECS label")
+        fig.text(0.5, 0.005,
+                 f"denominator = {out['metrics']['n_pos']} credible ECS edits vs "
+                 f"{out['metrics']['n_neg']} ECS-negatives; precision here is against the "
+                 f"ECS label, never against human review",
+                 ha="center", fontsize=7, color="#4a5568")
+        ax.legend(loc="upper right", fontsize=8)
+        fig.tight_layout()
+        fig.savefig(args.out_curve, dpi=130)
+        print(f"wrote {args.out_curve}")
+    except Exception as e:
+        print(f"(PR curve not rendered: {e})")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/validate_recall.py
+++ b/bin/validate_recall.py
@@ -21,6 +21,20 @@ Usage
   validate_recall.py --scores  results/offtarget/wgs_hotspot_scores.csv \
                      --gold   "Manual Indel Review/cart_ecs/cart_ecs_merged.csv.gz"
 
+Why there is no precision / F-beta here
+---------------------------------------
+Deliberate, and not an oversight. This table has confirmed POSITIVES only: 55 rows with
+manual_review == '1', one '1?', and ~80,440 NaN — and NaN means NOT REVIEWED, not
+reviewed-and-rejected. With no confirmed negatives there is no false-positive count, so
+precision, F1 and F-beta are simply not defined against it. Computing them anyway (by
+filling NaN with 0) would score every genuine discovery the reviewers never got to as a
+false positive and produce a confidently wrong number.
+
+Precision-bearing metrics therefore live in `bin/offtarget_metrics.py`, which uses the
+ECS label in training.tsv — a real two-class label — and says so on its own face. If a
+curated negative set ever exists, add it here as an explicit `--negatives` source; until
+then this script stays recall-only.
+
 Joins on (guide, chrom, start). The gold table keys samples by their review-sheet name
 (`CART_NS0011-ABTB1`); the pipeline keys them by CRAM sample (`ABTB1-KO-DNA`). Both
 carry the guide, so the guide is the join key and `--guide-alias` patches the handful of
@@ -155,6 +169,11 @@ def main():
         print(f"  on-target  : {int(on['called'].sum())}/{len(on)}")
     if len(off):
         print(f"  off-target : {int(off['called'].sum())}/{len(off)}")
+    # Say the limitation out loud, every run. Anyone reading a bare recall number is one
+    # short step from asking "and the precision?" — the answer has to travel with it.
+    print("  (recall only: this table has no confirmed negatives — NaN means UNREVIEWED,")
+    print("   not rejected, so precision/F-beta are undefined here. For PR-AUC, precision")
+    print("   and F2/F5 against the ECS label, see offtarget_metrics.{json,txt}.)")
 
     miss = site[~site["called"]]
     if len(miss):

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -42,7 +42,7 @@ process {
     }
 
     // Unified CRISPR Off-Target Workflow (-entry OFFTARGET)
-    withName: 'WGS_WORKLIST|PON_OFFTARGET_FILTER|HOTSPOT_TO_TABLE|SCORE_HOTSPOTS|BUILD_TRAINING_TABLE|RECALL_VS_VAF|RECONCILE_OFFTARGET_REPORT|ECS_INDELS' {
+    withName: 'WGS_WORKLIST|PON_OFFTARGET_FILTER|HOTSPOT_TO_TABLE|SCORE_HOTSPOTS|BUILD_TRAINING_TABLE|RECALL_VS_VAF|RECONCILE_OFFTARGET_REPORT|OFFTARGET_METRICS|ECS_INDELS' {
         publishDir = [
             path: { "${params.outdir}/offtarget" },
             mode: params.publish_dir_mode,
@@ -84,7 +84,7 @@ process {
     }
 
     // Table joins + report + recall curve — trivial pandas steps (finish in ~1 s–1.5 min).
-    withName: 'HOTSPOT_TO_TABLE|BUILD_TRAINING_TABLE|RECALL_VS_VAF|RECONCILE_OFFTARGET_REPORT' {
+    withName: 'HOTSPOT_TO_TABLE|BUILD_TRAINING_TABLE|RECALL_VS_VAF|RECONCILE_OFFTARGET_REPORT|OFFTARGET_METRICS' {
         cpus   = { 1 }
         memory = { check_max( 4.GB * task.attempt, 'memory' ) }   // was process_low = 12 GB
         time   = { check_max( 1.h  * task.attempt, 'time'   ) }

--- a/docs/OFFTARGET_WORKFLOW.md
+++ b/docs/OFFTARGET_WORKFLOW.md
@@ -29,12 +29,16 @@ Everything lands in `<outdir>/offtarget/`.
   This is the ground truth.
 - **`recall_vs_vaf.csv` / `.png`** — how often the WGS catches an ECS-confirmed edit, split by VAF.
   Read it as: above this VAF, believe the WGS calls; below it, don't.
+- **`offtarget_metrics.json` / `.txt`** — PR-AUC and recall-weighted F-beta (F2, F5) for the WGS
+  shape score, plus precision/recall at the reported operating point. `.txt` is the one-screen
+  human read; `.json` is the machine-readable copy. **Read the denominator section first** —
+  the precision in here is against the ECS label, *not* against human review.
 - **`training.tsv`** — one row per hotspot lining up the WGS features against the ECS answer, with a
   `label` marking genuine *somatic* edits: ECS shows an edit **and** it's absent from the matched WGS
   normal (germline/recurrent sites are demoted, so they don't get called edits). Only used to retrain
   the model offline; ignore it on a normal run.
 
-The last two only show up when you give it both ECS and WGS.
+The last three only show up when you give it both ECS and WGS.
 
 ### Verification snapshots (optional)
 
@@ -115,6 +119,8 @@ You hand it one samplesheet with these columns:
 | `offtarget_rescue_min_ifrac` | 0.15 | rescue: minimum indel fraction in the edited sample |
 | `offtarget_rescue_min_conc` | 0.5 | rescue: minimum positional concordance (clonality) |
 | `offtarget_rescue_min_span` | 20 | rescue: minimum spanning reads |
+| `offtarget_metrics_betas` | `2,5` | F-beta weights for `offtarget_metrics.{json,txt}` |
+| `offtarget_metrics_negatives` | `ecs_negative` | PR-AUC negative set; `all_label0` also counts germline-demoted ECS edits |
 
 ## Reading `recall_vs_vaf.csv` (the denominator matters more than the number)
 
@@ -144,6 +150,81 @@ them — so they are reported separately instead of being charged against recall
 On the AAVS1 run this turns a meaningless `0.002` into an interpretable curve: the top VAF bin
 is 4 credible edits, 2 of them without WGS coverage, and **2/2 of the evaluable ones detected**.
 Low-VAF bins still read low — that is the genuine WGS depth floor, and it is the honest result.
+
+## Reading `offtarget_metrics.txt` (PR-AUC and F2/F5)
+
+A recall-first diagnostic is judged on PR-AUC and recall-weighted F-beta, not on ROC-AUC. At the
+positive prevalence this assay works at, ROC-AUC is dominated by the true-negative mass and reads
+flatteringly high; PR-AUC has no such property. It is still reported, just not as the headline.
+
+```
+F_beta = (1 + beta^2) * P * R / (beta^2 * P + R)
+```
+
+beta weights recall `beta^2`× more than precision (β=2 → 4×, β=5 → 25×). F_beta is **monotone in
+beta** — it rises with beta when recall > precision and falls when precision > recall — so F1 is
+always an *endpoint* of {F1, F2, F5}, never the middle value. F1 in the middle means the beta
+wiring is inverted.
+
+### You cannot compute precision from the manual review
+
+The human-reviewed table (`cart_ecs_merged.csv.gz`) has **55** rows with `manual_review == '1'`,
+one `'1?'`, and **80,440 NaN**. `NaN` means *not reviewed* — not reviewed-and-rejected. There are
+no confirmed negatives in it, so precision against it is not defined. Filling those NaNs with 0
+would count every genuine discovery the reviewers never got to as a false positive and produce a
+confidently wrong number. That is why `validate_recall.py` reports **recall only**, and it stays
+that way.
+
+So there are **two denominators**, kept strictly apart and both stamped into every output:
+
+| | denominator | what it supports | where |
+|---|---|---|---|
+| 1 | ECS label in `training.tsv` (a real two-class label) | PR-AUC, precision, F-beta | `offtarget_metrics.{json,txt}` |
+| 2 | human manual review (positives only) | **recall only** — the gold standard | `bin/validate_recall.py` |
+
+The positive set uses the same credibility gates as the recall curve (`ecs_if >=
+offtarget_min_ecs_vaf`, `ecs_indel_reads >= offtarget_min_ecs_reads`); without them the positives
+are re-polluted with sub-0.5%-VAF ECS noise and every metric becomes meaningless. `label == 1`
+rows that fail those gates are **ambiguous, not negative** — ECS saw something below the
+credibility floor — so they are excluded and counted, for exactly the same reason the unreviewed
+manual-review rows are. Rows with no score (`INSUFFICIENT COVERAGE` / `NO CRAM`) are excluded from
+the ranking metrics and the exclusion count is reported; they are never filled with 0.
+
+`label == 0` is likewise two populations: genuine ECS-negatives, and ECS edits **demoted because
+the indel is in the matched normal**. The germline-demoted rows carry a real indel, so the shape
+ranker correctly scores them high — germline rejection is a separate downstream gate, and none of
+them are called `LIKELY EDIT`. Including them in the *ranking* denominator charges the ranker with
+a job it does not do, so `offtarget_metrics_negatives` defaults to `ecs_negative`. The alternative
+is always printed as a labelled sensitivity block, so the choice is visible rather than buried.
+
+### What the AAVS1 cohort actually shows
+
+```
+n_pos / n_neg : 631 / 299     prevalence 0.679
+PR-AUC        : 0.655  (0.96x prevalence)
+operating pt  : TP 21  FP 5  FN 610  TN 294
+                precision 0.808   recall 0.033   F1 0.064   F2 0.041   F5 0.035
+```
+
+PR-AUC **below** prevalence normally means a useless ranker or a bug. Here it is neither, and the
+by-VAF-floor table in the same file shows why — 427 of the 631 credible positives sit in the
+0.5–1% VAF bin, which WGS at ~30× genuinely cannot see:
+
+| ECS VAF floor | n_pos | prevalence | PR-AUC | lift | ROC-AUC |
+|---|---|---|---|---|---|
+| ≥ 0.005 | 631 | 0.678 | 0.655 | 0.96× | 0.439 |
+| ≥ 0.01 | 204 | 0.406 | 0.456 | 1.12× | 0.488 |
+| ≥ 0.02 | 58 | 0.162 | 0.305 | 1.87× | 0.622 |
+| ≥ 0.05 | 14 | 0.045 | 0.290 | **6.49×** | 0.931 |
+| ≥ 0.10 | 9 | 0.029 | 0.257 | **8.81×** | 0.939 |
+
+The ranker is strongly informative exactly where WGS can see (≥5% VAF: 6.5× lift, ROC 0.93) and
+uninformative at the depth floor. That is the same conclusion the recall curve reaches — recall
+`0.033` over 631 evaluable sites here reconciles exactly with `recall_vs_vaf.csv` — stated in
+precision/recall terms. A **flat** lift at every VAF floor would be the real alarm.
+
+Precision `0.808` is against the ECS label. It is **not** a claim about precision versus human
+review, and the file says so on its own face.
 
 ## The high-evidence rescue (why recall is 100%, not 90%)
 

--- a/modules/local/offtarget_metrics.nf
+++ b/modules/local/offtarget_metrics.nf
@@ -1,0 +1,43 @@
+// OFFTARGET_METRICS — the metrics a recall-first diagnostic is judged on: PR-AUC and
+// recall-weighted F-beta (F2, F5), plus precision/recall/F1 at the reported operating
+// point. Computed against the ECS label in training.tsv, which has a genuine two-class
+// label — NEVER against the manual review, which has no confirmed negatives (its NaNs
+// mean "unreviewed", not "rejected"). Recall vs manual review stays with
+// bin/validate_recall.py and stays recall-only. Both denominators are stamped into the
+// outputs so the two can never be confused.
+process OFFTARGET_METRICS {
+    tag "cohort"
+    label 'process_low'
+    container "ghcr.io/dhslab/docker-scge-offtarget:260710"
+
+    input:
+    path training
+
+    output:
+    path "offtarget_metrics.json",                     emit: metrics
+    path "offtarget_metrics.txt",                      emit: report
+    path "offtarget_pr_curve.png", optional: true,     emit: curve
+    path "versions.yml",                               emit: versions
+
+    script:
+    """
+    python ${projectDir}/bin/offtarget_metrics.py \\
+        --training ${training} \\
+        --hi ${params.offtarget_hi_score} \\
+        --min-ecs-vaf ${params.offtarget_min_ecs_vaf} \\
+        --min-ecs-reads ${params.offtarget_min_ecs_reads} \\
+        --betas ${params.offtarget_metrics_betas} \\
+        --negatives ${params.offtarget_metrics_negatives} \\
+        --out-json offtarget_metrics.json \\
+        --out-txt offtarget_metrics.txt \\
+        --out-curve offtarget_pr_curve.png
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed 's/Python //g')
+    END_VERSIONS
+    """
+
+    stub:
+    "touch offtarget_metrics.json offtarget_metrics.txt offtarget_pr_curve.png versions.yml"
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -69,6 +69,8 @@ params {
     offtarget_target_recall       = 0.80    // report VAF floor where binned recall first reaches this
     offtarget_min_ecs_vaf         = 0.005   // recall denominator: ECS VAF floor below which a call is assay noise, not an edit
     offtarget_min_ecs_reads       = 5       // recall denominator: ECS indel reads required to believe a site is a real edit
+    offtarget_metrics_betas       = '2,5'   // F-beta weights for the clinical metrics report (recall weighted beta^2 x)
+    offtarget_metrics_negatives   = 'ecs_negative' // PR-AUC negatives: 'ecs_negative' (label==0 & ecs_is_edit==0) or 'all_label0' (also counts germline-demoted ECS edits)
     offtarget_hotspot_pad         = 25      // bp window to match a worklist candidate to a hotspot
 
     // Auto-hotspot finder (entry: -entry HOTSPOTS) — gRNA -> predicted off-target sites

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -224,6 +224,22 @@
                     "default": 5,
                     "description": "Recall denominator: ECS indel reads required to believe a site is a real edit",
                     "help_text": "VAF alone cannot separate a genuine low-VAF edit at high depth from a few stray reads; read support can. Set 0 to disable."
+                },
+                "offtarget_metrics_betas": {
+                    "type": "string",
+                    "default": "2,5",
+                    "description": "Comma-separated F-beta weights for the clinical metrics report",
+                    "help_text": "F_beta weights recall beta^2 times more than precision (beta=2 -> 4x, beta=5 -> 25x). F_beta is monotone in beta, so F1 is always an endpoint of the reported set, never the middle value."
+                },
+                "offtarget_metrics_negatives": {
+                    "type": "string",
+                    "default": "ecs_negative",
+                    "enum": [
+                        "ecs_negative",
+                        "all_label0"
+                    ],
+                    "description": "Negative set for PR-AUC: ECS-negative hotspots only, or all label==0 rows",
+                    "help_text": "label==0 is two populations: genuine ECS-negatives (ecs_is_edit==0) and ECS edits demoted because the indel is in the matched normal. The germline-demoted rows carry a real indel, so the shape ranker correctly scores them high and germline rejection is a separate downstream gate; including them charges the ranker with a job it does not do. Either way the alternative is reported as a labelled sensitivity block."
                 }
             }
         },

--- a/tests/test_offtarget_glue.py
+++ b/tests/test_offtarget_glue.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 
 import pandas as pd
+import pytest
 from conftest import BIN, run
 
 
@@ -163,3 +164,153 @@ def test_verdict_callers_unpack_three_values():
                     offenders.append(f"{path.name}:{node.lineno} unpacks {len(tgt.elts)}, want 3")
 
     assert not offenders, "verdict() arity mismatch: " + "; ".join(offenders)
+
+
+# ── offtarget_metrics.py: PR-AUC / F-beta on a hand-built frame ────────────────
+# Every expected value below is computable with a calculator, so a regression shows up
+# as a wrong number rather than a plausible-looking one.
+#
+#   11 credible positives (ecs_if >= 0.005, ecs_indel_reads >= 5), one of which has NO
+#      score (INSUFFICIENT COVERAGE) and is excluded from the ranking metrics
+#    5 ECS-negatives (label 0, ecs_is_edit 0)
+#    2 germline-demoted rows (label 0, ecs_is_edit 1) -> excluded from the DEFAULT
+#      negative set; the shape ranker is not the germline filter
+#    3 sub-credibility label==1 rows -> AMBIGUOUS, excluded, never counted as negatives
+#
+# Of the 10 scored positives, 4 are called LIKELY EDIT; 1 of the 5 negatives is.
+#   precision = 4/5  = 0.8      recall = 4/10 = 0.4
+#   F1 = 2(.8)(.4)/(.8+.4)            = 0.5333...
+#   F2 = 5(.8)(.4)/(4(.8)+.4)         = 1.6/3.6  = 0.4444...
+#   F5 = 26(.8)(.4)/(25(.8)+.4)       = 8.32/20.4 = 0.40784...
+#   recall_incl_unevaluable = 4/11    = 0.36363...
+# Scores separate the two classes perfectly, so PR-AUC and ROC-AUC are exactly 1.0.
+METRIC_COLS = ["sample", "guide", "chrom", "start", "score", "verdict",
+               "ecs_if", "ecs_is_edit", "ecs_indel_reads", "label"]
+
+_EDIT = "LIKELY EDIT"
+_ART = "ARTIFACT (shape)"
+
+
+def _metrics_frame():
+    rows = []
+    pos_scores = [0.90, 0.85, 0.80, 0.75, 0.70, 0.65, 0.60, 0.55, 0.50, 0.45]
+    for i, sc in enumerate(pos_scores):
+        rows.append(("s1", "G", f"chr{i + 1}", 1000 + i, sc,
+                     _EDIT if i < 4 else _ART, 0.20, 1, 50, 1))
+    # 11th credible positive: no WGS coverage -> no score, out of the ranking metrics
+    rows.append(("s1", "G", "chrU", 9000, float("nan"), "INSUFFICIENT COVERAGE",
+                 0.20, 1, 50, 1))
+    neg_scores = [0.40, 0.30, 0.20, 0.10, 0.05]
+    for i, sc in enumerate(neg_scores):
+        rows.append(("s1", "G", f"chrN{i}", 2000 + i, sc,
+                     _EDIT if i == 0 else _ART, 0.0, 0, 0, 0))
+    for i in range(2):                       # germline-demoted: real indel, in normal
+        rows.append(("s1", "G", f"chrG{i}", 3000 + i, 0.95,
+                     "GERMLINE/ARTIFACT (in normal)", 0.30, 1, 90, 0))
+    for i in range(3):                       # sub-credibility ECS signal -> ambiguous
+        rows.append(("s1", "G", f"chrA{i}", 4000 + i, 0.10, _ART, 0.001, 1, 2, 1))
+    return pd.DataFrame(rows, columns=METRIC_COLS)
+
+
+def _run_metrics(tmp_path, df, *extra):
+    df.to_csv(tmp_path / "training.tsv", sep="\t", index=False)
+    proc = run("offtarget_metrics.py", "--training", "training.tsv",
+               "--out-json", "m.json", "--out-txt", "m.txt", *extra, cwd=tmp_path)
+    import json
+    return json.loads((tmp_path / "m.json").read_text()), (tmp_path / "m.txt").read_text(), proc
+
+
+def test_offtarget_metrics_exact_values(tmp_path):
+    out, txt, _ = _run_metrics(tmp_path, _metrics_frame())
+    m, op = out["metrics"], out["metrics"]["operating_point"]
+
+    # denominator composition
+    assert (m["n_pos"], m["n_neg"]) == (10, 5)          # NaN-score positive not ranked
+    assert m["n_excluded_no_score"] == 1
+    assert m["n_excluded_no_score_pos"] == 1
+    assert out["counts"]["n_positives_credible"] == 11
+    assert out["counts"]["n_ambiguous"] == 3            # excluded, NOT negatives
+    assert out["counts"]["n_germline_demoted_excluded"] == 2
+
+    # perfect ranking -> PR-AUC and ROC-AUC are exactly 1
+    assert m["pr_auc"] == pytest.approx(1.0)
+    assert m["roc_auc"] == pytest.approx(1.0)
+    assert m["prevalence"] == pytest.approx(10 / 15)
+
+    # operating point, hand-computed
+    assert (op["tp"], op["fp"], op["fn"], op["tn"]) == (4, 1, 6, 4)
+    assert op["precision"] == pytest.approx(0.8)
+    assert op["recall"] == pytest.approx(0.4)
+    assert op["f1"] == pytest.approx(2 * 0.8 * 0.4 / (0.8 + 0.4))
+    assert op["f2"] == pytest.approx(1.6 / 3.6)
+    assert op["f5"] == pytest.approx(8.32 / 20.4)
+    assert op["recall_incl_unevaluable"] == pytest.approx(4 / 11)
+
+    # F_beta is monotone in beta: with precision > recall it DECREASES as beta rises, so
+    # F1 is an endpoint. F1 sitting in the middle means the beta wiring is inverted.
+    assert op["f1"] > op["f2"] > op["f5"]
+
+    # both denominators must be named in the human-readable report
+    assert "manual review" in txt.lower()
+    assert "UNREVIEWED" in txt
+    assert "NOT vs human review" in txt
+
+
+def test_offtarget_metrics_fbeta_favours_recall(tmp_path):
+    """Mirror image: when recall > precision, F_beta RISES with beta."""
+    df = _metrics_frame()
+    # call every scored positive plus all 5 negatives -> P = 10/15, R = 10/10
+    df["verdict"] = df["verdict"].where(df["verdict"] == "INSUFFICIENT COVERAGE", _EDIT)
+    # drop the 3 sub-credibility rows only (the ECS-negatives also have a low ecs_if,
+    # so filtering on ecs_if alone would silently take the negatives with them)
+    df = df[~((df["label"] == 1) & (df["ecs_indel_reads"] < 5))]
+    out, _txt, _ = _run_metrics(tmp_path, df, "--negatives", "all_label0")
+    op = out["metrics"]["operating_point"]
+    assert op["recall"] == pytest.approx(1.0)
+    assert op["precision"] == pytest.approx(10 / 17)    # 5 ECS-neg + 2 germline as FP
+    assert op["f1"] < op["f2"] < op["f5"]
+
+
+def test_offtarget_metrics_negative_set_switch(tmp_path):
+    """The germline-demoted rows are excluded by default and included on request; the
+    alternative is always reported as a labelled sensitivity block either way."""
+    default, _t, _ = _run_metrics(tmp_path, _metrics_frame())
+    strict, _t2, _ = _run_metrics(tmp_path, _metrics_frame(), "--negatives", "all_label0")
+    assert default["metrics"]["n_neg"] == 5
+    assert strict["metrics"]["n_neg"] == 7
+    assert any("all label==0" in s["definition"] for s in default["sensitivity"])
+
+
+def test_offtarget_metrics_ambiguous_never_silently_negative(tmp_path):
+    """Sub-credibility label==1 rows are the training-table analogue of the unreviewed
+    manual-review rows: excluded by default, counted as negatives only on request."""
+    default, _t, _ = _run_metrics(tmp_path, _metrics_frame())
+    forced, _t2, _ = _run_metrics(tmp_path, _metrics_frame(), "--ambiguous-as-negative")
+    assert default["metrics"]["n_neg"] == 5
+    assert forced["metrics"]["n_neg"] == 8              # + the 3 ambiguous rows
+    assert forced["counts"]["n_ambiguous"] == 0
+
+
+@pytest.mark.parametrize("mutate,expect", [
+    (lambda d: d[d["label"] == 1], "single-class"),          # no negatives at all
+    (lambda d: d.assign(ecs_if=0.0, ecs_indel_reads=0), "single-class"),  # no credible pos
+])
+def test_offtarget_metrics_degenerate_exits_zero(tmp_path, mutate, expect):
+    """A run with no credible positives is a legitimate result, not an error: the file
+    still has to be published, with nulls and an explanatory note."""
+    out, txt, proc = _run_metrics(tmp_path, mutate(_metrics_frame()))
+    assert proc.returncode == 0
+    assert out["metrics"] is None
+    assert expect in out["note"]
+    assert "manual review" in txt.lower()                # denominators still documented
+
+
+def test_offtarget_metrics_all_nan_scores_exits_zero(tmp_path):
+    """All-NaN scores must not be filled with 0 — that would fabricate confident
+    negatives. Ranking metrics go null, the exclusion count is reported."""
+    df = _metrics_frame()
+    df["score"] = float("nan")
+    out, _txt, proc = _run_metrics(tmp_path, df)
+    assert proc.returncode == 0
+    assert out["metrics"]["pr_auc"] is None
+    assert out["metrics"]["n_excluded_no_score"] == 16   # 11 pos + 5 neg


### PR DESCRIPTION
Reports the metrics a recall-first diagnostic is actually judged on. ROC-AUC and average_precision existed only at training time on a holdout; nothing reached a deployed run, and ROC-AUC is the wrong headline at this prevalence anyway.

Precision is NOT computable against the manual review: that table has 55 confirmed positives and ~80,440 NaN, where NaN means unreviewed rather than rejected. It has no confirmed negatives, so filling them in would score every discovery the reviewers never reached as a false positive. PR-AUC/F-beta therefore go on training.tsv, which carries a real two-class ECS label; recall vs manual review stays the gold standard and stays recall-only. Both denominators are stamped into every output.

- bin/offtarget_metrics.py: PR-AUC, ROC-AUC (not led with), precision/recall/F1/F-beta at the reported verdict, prevalence and the PR-AUC lift over it. Positives use the same credibility gates as the recall curve; sub-credibility label==1 rows are ambiguous, not negative, so they are excluded and counted. NaN-score rows (INSUFFICIENT COVERAGE / NO CRAM) are dropped from the ranking metrics and the exclusion count reported, never filled with 0. Degenerate cases emit nulls plus a note and exit 0.
- Negative set defaults to genuine ECS-negatives: the germline-demoted label==0 rows carry a real indel that a separate downstream gate rejects, so ranking the shape score against them charges it with a job it does not do. The alternative is always printed as a labelled sensitivity block.
- Per-VAF-floor breakdown, because a single PR-AUC over all credible positives is dominated by sub-1% VAF sites WGS at ~30x cannot see. On AAVS1 the lift rises from 0.96x at the 0.5% floor to 6.5x at 5% (ROC 0.93) — the documented depth floor, not a broken ranker. Recall 0.033 over 631 evaluable reconciles with recall_vs_vaf.csv.
- validate_recall.py stays recall-only and now says why, in the docstring and in its printout.
- Module + workflow wiring, params, schema, publishDir, docs, and unit tests with hand-computed precision/recall/F2/F5 plus the degenerate cases.

<!--
# nf-core/scge pull request

Many thanks for contributing to nf-core/scge!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/scge/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scge/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/scge _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
