### PR TITLE
offtarget: wire OFFTARGET_METRICS into the workflow; make stub runs w…

### DIFF
--- a/conf/stub.config
+++ b/conf/stub.config
@@ -14,11 +14,31 @@ params {
     config_profile_name        = 'Stub test profile'
     config_profile_description = 'Minimal test dataset to check pipeline function'
 
-    // No DRAGEN reference on a stub run. workflows/scge.nf validates refdir at parse
-    // time on EVERY entry (including OFFTARGET/HOTSPOTS), so leaving the real /storage2
-    // default in place hard-fails anywhere that path is absent — e.g. GitHub Actions.
-    // Null short-circuits the check; stub runs never touch a hash table.
-    refdir     = null
+    // workflows/scge.nf validates every reference path at PARSE time, via top-level
+    // `params.X ? Channel.fromPath(X, checkIfExists: true) : []` statements that run on
+    // EVERY entry — OFFTARGET and HOTSPOTS included, though neither uses DRAGEN or VEP.
+    // The defaults all point at /storage2, which exists on the cluster and nowhere else,
+    // so a stub run dies before scheduling a single process anywhere that path is absent
+    // (GitHub Actions, a laptop, a collaborator's cluster). Null short-circuits each
+    // ternary; stub runs never read any of these.
+    refdir             = null
+    fasta              = "${projectDir}/assets/stub/tiny.fa"
+    dbsnp              = null
+    adapter1           = null
+    adapter2           = null
+    snv_noisefile      = null
+    sv_noisefile       = null
+    cram_reference     = null
+    vepcache           = null
+    nirvana_path       = null
+    // file()'d unconditionally when run_crisprme is on, so it must EXIST (never null);
+    // stub processes only touch outputs, so any real directory satisfies it.
+    crisprme_index_dir = "${projectDir}/assets/stub"
+
+    // The transgene contig lives only in the real hg38+transgene FASTA. Both contig
+    // checks early-return on a null contig, so this skips the .fai lookup for the stub
+    // runs that don't pass their own --fasta.
+    transgene_name     = null
 
     // Limit resources so that this can run on GitHub Actions
     max_cpus   = 2

--- a/workflows/offtarget.nf
+++ b/workflows/offtarget.nf
@@ -9,7 +9,8 @@
        └─ wgs rows ─► WGS_WORKLIST ─► PON_OFFTARGET_FILTER ─► genome-wide homology-free worklist
                           │
        paired: HOTSPOT_TO_TABLE ─► SCORE_HOTSPOTS ─► BUILD_TRAINING_TABLE ─► training.tsv
-                                                     └► RECALL_VS_VAF ─► recall_vs_vaf.{csv,png}
+                                                     ├► RECALL_VS_VAF ─► recall_vs_vaf.{csv,png}
+                                                     └► OFFTARGET_METRICS ─► offtarget_metrics.{json,txt}
        all   : RECONCILE_OFFTARGET_REPORT ─► offtarget_report.csv  (is_hotspot / ecs_confirmed)
 
     Notes for the first real run:
@@ -28,6 +29,7 @@ include { HOTSPOT_TO_TABLE          } from '../modules/local/hotspot_to_table.nf
 include { SCORE_HOTSPOTS            } from '../modules/local/score_hotspots.nf'
 include { BUILD_TRAINING_TABLE      } from '../modules/local/build_training_table.nf'
 include { RECALL_VS_VAF             } from '../modules/local/recall_vs_vaf.nf'
+include { OFFTARGET_METRICS         } from '../modules/local/offtarget_metrics.nf'
 include { RECONCILE_OFFTARGET_REPORT } from '../modules/local/reconcile_offtarget_report.nf'
 include { GENERATE_HOTSPOTS          } from '../subworkflows/local/generate_hotspots.nf'
 
@@ -177,6 +179,10 @@ workflow OFFTARGET_WORKFLOW {
                        file(params.offtarget_shape_model), params.fasta)
         BUILD_TRAINING_TABLE(SCORE_HOTSPOTS.out.scores, HOTSPOT_TO_TABLE.out.truth, ch_ss)
         RECALL_VS_VAF(BUILD_TRAINING_TABLE.out.training)
+        // PR-AUC / F2 / F5 against the ECS label (training.tsv has a real two-class
+        // label). Recall vs the human review stays with validate_recall.py and stays
+        // recall-only — that table has no confirmed negatives to divide by.
+        OFFTARGET_METRICS(BUILD_TRAINING_TABLE.out.training)
         ch_truth = HOTSPOT_TO_TABLE.out.truth
     }
 


### PR DESCRIPTION
…ork off-cluster

Two fixes that both kept the metrics work from actually running.

1. workflows/offtarget.nf was left out of the original commit's `git add`, so OFFTARGET_METRICS was defined, parameterised and schema'd but never invoked — the process existed and nothing called it. The stub run appeared to exercise it only because the wiring was present uncommitted in the working tree.

2. Complete the stub reference-path fix. workflows/scge.nf validates every reference path at PARSE time through top-level `params.X ? Channel.fromPath(X, checkIfExists: true) : []` statements that run on EVERY entry, including OFFTARGET and HOTSPOTS, neither of which touches DRAGEN or VEP. All defaults point at /storage2, so a stub run dies before scheduling a process anywhere that path is absent. Nulling refdir alone just exposed the next path in the list; this covers the whole set. Two are deliberately not null: crisprme_index_dir is file()'d unconditionally when run_crisprme is on, and the OFFTARGET stub steps do not pass their own --fasta.

These stub jobs have never passed on CI: the parse-time checks landed 2025-09-30 and the offtarget CI workflow 2026-07-21, and the failure reproduces at the commit that introduced the workflow. Verified across all six stub invocations the workflow runs, with /storage2 simulated absent, and re-checked with /storage2 present so cluster behaviour is unchanged.

<!--
# nf-core/scge pull request

Many thanks for contributing to nf-core/scge!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/scge/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scge/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/scge _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
